### PR TITLE
Studio collects page operations

### DIFF
--- a/waspc/packages/ts-inspect/src/index.ts
+++ b/waspc/packages/ts-inspect/src/index.ts
@@ -1,4 +1,5 @@
 import { ExportsRequests, getExportsOfFiles } from "./exports.js";
+import { OperationsRequests, getOperationsOfFiles } from "./operations.js";
 
 async function readAllFromStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -15,10 +16,22 @@ async function readAllFromStdin(): Promise<string> {
 async function main() {
   const inputStr = await readAllFromStdin();
   const input = JSON.parse(inputStr);
-  const requests = ExportsRequests.parse(input);
 
-  let exports = {};
-  for (let request of requests) {
+  const mode = process.argv[2] ?? "exports";
+  if (mode === "operations") {
+    const requests = OperationsRequests.parse(input);
+    let ops: Record<string, string[]> = {};
+    for (const request of requests) {
+      const newOps = await getOperationsOfFiles(request);
+      ops = { ...ops, ...newOps };
+    }
+    console.log(JSON.stringify(ops));
+    return;
+  }
+
+  const requests = ExportsRequests.parse(input);
+  let exports: Record<string, any[]> = {};
+  for (const request of requests) {
     const newExports = await getExportsOfFiles(request);
     exports = { ...exports, ...newExports };
   }
@@ -29,3 +42,4 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+

--- a/waspc/packages/ts-inspect/src/operations.ts
+++ b/waspc/packages/ts-inspect/src/operations.ts
@@ -1,0 +1,71 @@
+import * as fs from "fs/promises";
+import JSON5 from "json5";
+import * as path from "path";
+import ts from "typescript";
+import { z } from "zod";
+
+export const OperationsRequest = z.object({
+  tsconfig: z.string().optional(),
+  filepaths: z.array(z.string()),
+});
+
+export const OperationsRequests = z.array(OperationsRequest);
+
+export type OperationsRequest = z.infer<typeof OperationsRequest>;
+
+export async function getOperationsOfFiles(
+  request: OperationsRequest,
+): Promise<{ [file: string]: string[] }> {
+  let compilerOptions: ts.CompilerOptions = {};
+
+  if (request.tsconfig) {
+    compilerOptions = await loadCompilerOptionsFromTsConfig(request.tsconfig);
+  }
+
+  const operationsMap: { [file: string]: string[] } = {};
+
+  const program = ts.createProgram(request.filepaths, compilerOptions);
+
+  for (const filename of request.filepaths) {
+    const source = program.getSourceFile(filename);
+    if (!source) {
+      operationsMap[filename] = [];
+      continue;
+    }
+    const ops: string[] = [];
+    function visit(node: ts.Node) {
+      if (ts.isCallExpression(node)) {
+        const expr = node.expression;
+        if (ts.isIdentifier(expr) && (expr.text === "useQuery" || expr.text === "useAction")) {
+          const arg = node.arguments[0];
+          if (arg && ts.isIdentifier(arg)) {
+            ops.push(arg.text);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(source);
+    operationsMap[filename] = ops;
+  }
+
+  return operationsMap;
+}
+
+async function loadCompilerOptionsFromTsConfig(
+  tsconfig: string,
+): Promise<ts.CompilerOptions> {
+  const configJson = JSON5.parse(await fs.readFile(tsconfig, "utf8"));
+  const basePath = path.dirname(tsconfig);
+
+  const { options, errors } = ts.convertCompilerOptionsFromJson(
+    configJson.compilerOptions,
+    basePath,
+    tsconfig,
+  );
+  if (errors && errors.length) {
+    throw errors;
+  }
+  return options;
+}
+

--- a/waspc/src/Wasp/Studio/PageOperations.hs
+++ b/waspc/src/Wasp/Studio/PageOperations.hs
@@ -1,0 +1,51 @@
+module Wasp.Studio.PageOperations
+  ( PageOperations,
+    collectPageOperations,
+  ) where
+
+import Control.Monad (forM)
+import qualified Data.HashMap.Strict as M
+import qualified StrongPath as SP
+import qualified System.Directory as Dir
+import System.FilePath ((<.>), takeExtension, (</>))
+import Wasp.AppSpec (AppSpec)
+import qualified Wasp.AppSpec as AS
+import qualified Wasp.AppSpec.ExtImport as AS.ExtImport
+import qualified Wasp.AppSpec.Page as AS.Page
+import Wasp.Project.Common (WaspProjectDir, srcDirInWaspProjectDir)
+import qualified Wasp.TypeScript.Inspect.Operations as TS
+
+-- | Map from page name to list of operations referenced in that page.
+type PageOperations = M.HashMap String [String]
+
+collectPageOperations :: SP.Path' SP.Abs (SP.Dir WaspProjectDir) -> AppSpec -> IO (Either String PageOperations)
+collectPageOperations waspDir spec = do
+  let srcDir = waspDir SP.</> srcDirInWaspProjectDir
+  let tsconfig = waspDir SP.</> AS.srcTsConfigPath spec
+  reqs <- forM (AS.getPages spec) $ \(name, page) -> do
+    fp <- resolvePageFile srcDir (AS.ExtImport.path $ AS.Page.component page)
+    let pathStr = SP.fromAbsFile fp
+    return (name, TS.TsOperationsRequest {TS.filepaths = [pathStr], TS.tsconfig = Just $ SP.fromAbsFile tsconfig})
+  let tsRequests = map snd reqs
+  TS.getOperationsOfTsFiles tsRequests >>= \case
+    Left err -> return $ Left err
+    Right (TS.TsOperationsResponse resMap) -> do
+      let pageOps = M.fromList $ flip map reqs $ \(name, r) ->
+            let path = head (TS.filepaths r)
+             in (name, M.findWithDefault [] path resMap)
+      return $ Right pageOps
+
+resolvePageFile :: SP.Path' SP.Abs (SP.Dir d) -> SP.Path' SP.Rel SP.File' -> IO (SP.Path' SP.Abs SP.File')
+resolvePageFile srcDir relFile = do
+  let base = SP.fromAbsDir srcDir </> SP.fromRelFile relFile
+  if takeExtension base /= ""
+    then parse base
+    else tryExt ["ts", "tsx", "js", "jsx"]
+  where
+    parse p = maybe (error $ "Invalid path: " ++ p) return (SP.parseAbsFile p)
+    tryExt [] = parse base
+    tryExt (e:es) = do
+      let p = base <.> e
+      exists <- Dir.doesFileExist p
+      if exists then parse p else tryExt es
+

--- a/waspc/src/Wasp/TypeScript/Inspect/Operations.hs
+++ b/waspc/src/Wasp/TypeScript/Inspect/Operations.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Wasp.TypeScript.Inspect.Operations
+  ( getOperationsOfTsFiles,
+    TsOperationsRequest (..),
+    TsOperationsResponse (..),
+  ) where
+
+import Data.Aeson (FromJSON, ToJSON (toEncoding), decode, encode, defaultOptions, genericToEncoding)
+import qualified Data.ByteString.Lazy.UTF8 as BS
+import Data.Conduit.Process.Typed (ExitCode (ExitSuccess))
+import qualified Data.HashMap.Strict as M
+import GHC.Generics (Generic)
+import qualified System.Process as P
+import Wasp.NodePackageFFI (RunnablePackage (TsInspectPackage), getPackageProcessOptions)
+
+-- | Map from file path to list of operation names found in that file.
+newtype TsOperationsResponse = TsOperationsResponse (M.HashMap FilePath [String])
+  deriving (Eq, Show, FromJSON)
+
+-- | Request for operations used in files.
+data TsOperationsRequest = TsOperationsRequest
+  { filepaths :: ![FilePath],
+    tsconfig :: !(Maybe FilePath)
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON TsOperationsRequest where
+  toEncoding = genericToEncoding defaultOptions
+
+-- | Attempt to get list of operation names referenced via useQuery/useAction hooks.
+getOperationsOfTsFiles :: [TsOperationsRequest] -> IO (Either String TsOperationsResponse)
+getOperationsOfTsFiles requests = do
+  let requestJSON = BS.toString $ encode requests
+  cp <- getPackageProcessOptions TsInspectPackage ["operations"]
+  (exitCode, response, err) <- P.readCreateProcessWithExitCode cp requestJSON
+  case exitCode of
+    ExitSuccess -> case decode $ BS.fromString response of
+      Nothing -> return $ Left $ "invalid response JSON from ts-inspect: " ++ response
+      Just ops -> return $ Right ops
+    _ -> return $ Left err
+

--- a/waspc/test/StudioDataTest.hs
+++ b/waspc/test/StudioDataTest.hs
@@ -1,0 +1,44 @@
+module StudioDataTest where
+
+import Control.Monad (void)
+import Data.Aeson (FromJSON, decode)
+import GHC.Generics (Generic)
+import qualified Data.ByteString.Lazy as BSL
+import Data.List (find)
+import Data.Maybe (fromJust, fromMaybe)
+import qualified StrongPath as SP
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Tasty.Hspec
+import Wasp.Cli.Command.Compile (defaultCompileOptions)
+import Wasp.Cli.Command.Studio (generateStudioDataFile)
+import qualified Wasp.Project.Analyze as Analyze
+import Wasp.Project.Common (WaspProjectDir)
+import qualified Wasp.Util.IO as IO
+import Fixtures (systemSPRoot)
+
+newtype StudioData = StudioData {pages :: [StudioPage]} deriving (Generic, Show)
+instance FromJSON StudioData
+
+data StudioPage = StudioPage {name :: String, operations :: [String]} deriving (Generic, Show)
+instance FromJSON StudioPage
+
+spec_StudioDataTest :: Spec
+spec_StudioDataTest = describe "generateStudioDataFile" $ do
+  it "detects useQuery operations in TodoApp" $
+    withSystemTempDirectory "studio-test" $ \tmp -> do
+      let exampleDir = systemSPRoot SP.</> [SP.reldir|workspace/wasp/examples/tutorials/TodoApp|]
+      let tmpDir = fromJust $ SP.parseAbsDir tmp
+      IO.copyDirectory exampleDir tmpDir
+      let opts = defaultCompileOptions tmpDir
+      (appSpecOrErr, _) <- Analyze.analyzeWaspProject tmpDir opts
+      case appSpecOrErr of
+        Left errs -> expectationFailure $ show errs
+        Right spec -> do
+          dataFile <- generateStudioDataFile tmpDir spec
+          bs <- BSL.readFile (SP.fromAbsFile dataFile)
+          case decode bs :: Maybe StudioData of
+            Nothing -> expectationFailure "failed to decode json"
+            Just (StudioData ps) -> do
+              let ops = fromMaybe [] $ operations <$> find ((== "MainPage") . name) ps
+              ops `shouldBe` ["getTasks"]
+

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -432,6 +432,8 @@ library
     Wasp.SemanticVersion.VersionBound
     Wasp.SemanticVersion.Version
     Wasp.TypeScript.Inspect.Exports
+    Wasp.TypeScript.Inspect.Operations
+    Wasp.Studio.PageOperations
     Wasp.Util
     Wasp.Util.Aeson
     Wasp.Util.Control.Monad
@@ -704,6 +706,7 @@ test-suite waspc-test
     Paths_waspc
     Generator.NpmDependenciesTest
     JsImportTest
+    StudioDataTest
 
 test-suite waspls-test
   import: common-all, common-exe


### PR DESCRIPTION
## Summary
- expose page operations via ts-inspect
- parse useQuery/useAction from page components
- generate studio data with operations per page
- add tests for studio data json

## Testing
- `cabal test waspc-test --test-show-details=streaming` *(fails: cabal not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dac7678308333a472aeea3e45d611