### PR TITLE
Add CRUD data to studio output

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Studio.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Studio.hs
@@ -19,10 +19,12 @@ import qualified System.Directory as Dir
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Api as AS.Api
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.Crud as AS.Crud
 import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.Job as AS.Job
 import Wasp.AppSpec.Operation (Operation (..))
 import qualified Wasp.AppSpec.Operation as Operation
+import Wasp.Generator.Crud (crudDeclarationToOperationsList)
 import qualified Wasp.AppSpec.Page as AS.Page
 import qualified Wasp.AppSpec.Route as AS.Route
 import qualified Wasp.AppSpec.Valid as ASV
@@ -130,6 +132,17 @@ makeAppInfoJson waspDir spec = do
                   ]
             )
             (AS.getOperations spec),
+        "cruds"
+          .= map
+            ( \(name, crud) ->
+                object
+                  [ "name" .= name,
+                    "operations"
+                      .= map (show . fst) (crudDeclarationToOperationsList crud),
+                    "entities" .= getLinkedEntitiesData spec (Just [AS.Crud.entity crud])
+                  ]
+            )
+            (AS.getCruds spec),
         "entities"
           .= map
             ( \(name, _entity) -> object ["name" .= name] )

--- a/waspc/test/StudioDataTest.hs
+++ b/waspc/test/StudioDataTest.hs
@@ -16,11 +16,27 @@ import Wasp.Project.Common (WaspProjectDir)
 import qualified Wasp.Util.IO as IO
 import Fixtures (systemSPRoot)
 
-newtype StudioData = StudioData {pages :: [StudioPage]} deriving (Generic, Show)
+data StudioData = StudioData
+  { pages :: [StudioPage],
+    cruds :: Maybe [StudioCrud]
+  }
+  deriving (Generic, Show)
 instance FromJSON StudioData
 
-data StudioPage = StudioPage {name :: String, operations :: [String]} deriving (Generic, Show)
+data StudioPage = StudioPage {pageName :: String, operations :: [String]} deriving (Generic, Show)
 instance FromJSON StudioPage
+
+data StudioCrud = StudioCrud
+  { crudName :: String,
+    crudOperations :: [String],
+    crudEntities :: [StudioEntity]
+  }
+  deriving (Generic, Show)
+instance FromJSON StudioCrud
+
+newtype StudioEntity = StudioEntity {entityName :: String}
+  deriving (Generic, Show)
+instance FromJSON StudioEntity
 
 spec_StudioDataTest :: Spec
 spec_StudioDataTest = describe "generateStudioDataFile" $ do
@@ -38,7 +54,31 @@ spec_StudioDataTest = describe "generateStudioDataFile" $ do
           bs <- BSL.readFile (SP.fromAbsFile dataFile)
           case decode bs :: Maybe StudioData of
             Nothing -> expectationFailure "failed to decode json"
-            Just (StudioData ps) -> do
-              let ops = fromMaybe [] $ operations <$> find ((== "MainPage") . name) ps
-              ops `shouldBe` ["getTasks"]
+            Just (StudioData ps _) -> do
+                let ops = fromMaybe [] $ operations <$> find ((== "MainPage") . pageName) ps
+                ops `shouldBe` ["getTasks"]
+
+  it "includes CRUD info for tasks" $
+    withSystemTempDirectory "studio-crud-test" $ \tmp -> do
+      let exampleDir = systemSPRoot SP.</> [SP.reldir|workspace/wasp/waspc/examples/todoApp|]
+      let tmpDir = fromJust $ SP.parseAbsDir tmp
+      IO.copyDirectory exampleDir tmpDir
+      let opts = defaultCompileOptions tmpDir
+      (appSpecOrErr, _) <- Analyze.analyzeWaspProject tmpDir opts
+      case appSpecOrErr of
+        Left errs -> expectationFailure $ show errs
+        Right spec -> do
+          dataFile <- generateStudioDataFile tmpDir spec
+          bs <- BSL.readFile (SP.fromAbsFile dataFile)
+          case decode bs :: Maybe StudioData of
+            Nothing -> expectationFailure "failed to decode json"
+            Just (StudioData _ (Just crs)) -> do
+              let findCrud c = if crudName c == "tasks" then Just c else Nothing
+              case find (\c -> crudName c == "tasks") crs of
+                Nothing -> expectationFailure "tasks crud not found"
+                Just c -> do
+                  crudOperations c `shouldBe` ["Get","GetAll","Create","Update","Delete"]
+                  fmap entityName (crudEntities c) `shouldBe` ["Task"]
+            Just (StudioData _ Nothing) -> expectationFailure "cruds missing"
+
 


### PR DESCRIPTION
## Summary
- expose CRUD declarations in studio data
- test CRUD output is included in `.wasp-studio-data.json`

## Testing
- `cabal test waspc-test` *(fails: `cabal: command not found`)* 

------
https://chatgpt.com/codex/tasks/task_e_686db2d04b488333aad75560dd58d338