### PR TITLE
Add meta placeholders to React index template

### DIFF
--- a/waspc/data/Generator/templates/react-app/index.html
+++ b/waspc/data/Generator/templates/react-app/index.html
@@ -9,6 +9,11 @@
         />
         <link rel="manifest" href="/manifest.json" />
 
+        <meta name="description" content="{= metaDescription =}" />
+        <meta property="og:title" content="{= ogTitle =}" />
+        <meta property="og:description" content="{= ogDescription =}" />
+        <link rel="canonical" href="{= canonicalUrl =}" />
+
         {=& head =}
 
         <title>{= title =}</title>

--- a/waspc/packages/wasp-config/__tests__/mapTsAppSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/packages/wasp-config/__tests__/mapTsAppSpecToAppSpecDecls.unit.test.ts
@@ -85,6 +85,10 @@ describe("mapApp", () => {
         version: tsAppSpec.app.config.wasp.version,
       },
       title: tsAppSpec.app.config.title,
+      metaDescription: tsAppSpec.app.config.metaDescription,
+      ogTitle: tsAppSpec.app.config.ogTitle,
+      ogDescription: tsAppSpec.app.config.ogDescription,
+      canonicalUrl: tsAppSpec.app.config.canonicalUrl,
       head: tsAppSpec.app.config.head,
       auth:
         tsAppSpec.auth &&

--- a/waspc/packages/wasp-config/__tests__/testFixtures.ts
+++ b/waspc/packages/wasp-config/__tests__/testFixtures.ts
@@ -116,6 +116,10 @@ export function getAppConfig(
         config: {
           title: "Mock App",
           wasp: { version: "^0.16.3" },
+          metaDescription: "Description",
+          ogTitle: "OG Title",
+          ogDescription: "OG Description",
+          canonicalUrl: "https://example.com",
           head: ['<link rel="icon" href="/favicon.ico" />'],
         },
       } satisfies FullNamedConfig<TsAppSpec.AppConfig>;

--- a/waspc/packages/wasp-config/src/appSpec.ts
+++ b/waspc/packages/wasp-config/src/appSpec.ts
@@ -93,6 +93,10 @@ export type Crud = {
 export type App = {
   wasp: Wasp;
   title: string;
+  metaDescription: Optional<string>;
+  ogTitle: Optional<string>;
+  ogDescription: Optional<string>;
+  canonicalUrl: Optional<string>;
   head: Optional<string[]>;
   auth: Optional<Auth>;
   server: Optional<Server>;

--- a/waspc/packages/wasp-config/src/mapTsAppSpecToAppSpecDecls.ts
+++ b/waspc/packages/wasp-config/src/mapTsAppSpecToAppSpecDecls.ts
@@ -193,10 +193,22 @@ export function mapApp(
   emailSender?: TsAppSpec.EmailSenderConfig,
   webSocket?: TsAppSpec.WebsocketConfig,
 ): AppSpec.App {
-  const { title, wasp, head } = app;
+  const {
+    title,
+    wasp,
+    head,
+    metaDescription,
+    ogTitle,
+    ogDescription,
+    canonicalUrl,
+  } = app;
   return {
     wasp,
     title,
+    metaDescription,
+    ogTitle,
+    ogDescription,
+    canonicalUrl,
     head,
     auth: auth && mapAuth(auth, entityRefParser, routeRefParser),
     client: client && mapClient(client),

--- a/waspc/packages/wasp-config/src/publicApi/tsAppSpec.ts
+++ b/waspc/packages/wasp-config/src/publicApi/tsAppSpec.ts
@@ -22,6 +22,10 @@ export type TsAppSpec = {
 export type AppConfig = {
   title: string;
   wasp: AppSpec.Wasp;
+  metaDescription?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  canonicalUrl?: string;
   head?: string[];
 };
 

--- a/waspc/src/Wasp/AppSpec/App.hs
+++ b/waspc/src/Wasp/AppSpec/App.hs
@@ -19,6 +19,10 @@ import Wasp.AppSpec.Core.IsDecl (IsDecl)
 data App = App
   { wasp :: Wasp,
     title :: String,
+    metaDescription :: Maybe String,
+    ogTitle :: Maybe String,
+    ogDescription :: Maybe String,
+    canonicalUrl :: Maybe String,
     head :: Maybe [String],
     auth :: Maybe Auth,
     server :: Maybe Server,

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -193,6 +193,10 @@ genIndexHtml spec =
     templateData =
       object
         [ "title" .= (AS.App.title (snd $ getApp spec) :: String),
+          "metaDescription" .= (AS.App.metaDescription (snd $ getApp spec) :: Maybe String),
+          "ogTitle" .= (AS.App.ogTitle (snd $ getApp spec) :: Maybe String),
+          "ogDescription" .= (AS.App.ogDescription (snd $ getApp spec) :: Maybe String),
+          "canonicalUrl" .= (AS.App.canonicalUrl (snd $ getApp spec) :: Maybe String),
           "head" .= (maybe "" (intercalate "\n") (AS.App.head $ snd $ getApp spec) :: String)
         ]
 


### PR DESCRIPTION
## Summary
- extend app spec with SEO-related fields
- pass new fields to the index.html template
- expose the fields through the TypeScript config
- update template with new meta tags
- adjust mapping utils and tests

## Testing
- `npx prettier --check waspc/packages/wasp-config/src/publicApi/tsAppSpec.ts waspc/packages/wasp-config/src/appSpec.ts waspc/packages/wasp-config/src/mapTsAppSpecToAppSpecDecls.ts waspc/packages/wasp-config/__tests__/testFixtures.ts waspc/packages/wasp-config/__tests__/mapTsAppSpecToAppSpecDecls.unit.test.ts`
- `npm test` in `waspc/packages/wasp-config`


------
https://chatgpt.com/codex/tasks/task_e_686db8bbb0108333ad73179c1f457bd1