### PR TITLE
Add react-helmet-async integration

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/components/PageHelmet.tsx
+++ b/waspc/data/Generator/templates/react-app/src/components/PageHelmet.tsx
@@ -1,0 +1,28 @@
+{{={= =}=}}
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+
+export type MetaTag = {
+  name: string
+  content: string
+}
+
+export interface PageHead {
+  title?: string
+  meta?: MetaTag[]
+}
+
+/**
+ * Renders document head elements using react-helmet-async.
+ * Helps decouple pages from head management for easier testing.
+ */
+export function PageHelmet({ title, meta = [] }: PageHead) {
+  return (
+    <Helmet>
+      {title && <title>{title}</title>}
+      {meta.map((m) => (
+        <meta key={m.name} name={m.name} content={m.content} />
+      ))}
+    </Helmet>
+  )
+}

--- a/waspc/data/Generator/templates/react-app/src/index.tsx
+++ b/waspc/data/Generator/templates/react-app/src/index.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-import { router } from './router'
+import { Router } from './router'
+import { HelmetProvider } from 'react-helmet-async'
 import {
   initializeQueryClient,
   queryClientInitialized,
@@ -32,16 +33,18 @@ async function render() {
   const queryClient = await queryClientInitialized
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        {=# areWebSocketsUsed =}
-        <WebSocketProvider>
-          {router}
-        </WebSocketProvider>
-        {=/ areWebSocketsUsed =}
-        {=^ areWebSocketsUsed =}
-        {router}
-        {=/ areWebSocketsUsed =}
-      </QueryClientProvider>
+      <HelmetProvider>
+        <QueryClientProvider client={queryClient}>
+          {=# areWebSocketsUsed =}
+          <WebSocketProvider>
+            <Router />
+          </WebSocketProvider>
+          {=/ areWebSocketsUsed =}
+          {=^ areWebSocketsUsed =}
+          <Router />
+          {=/ areWebSocketsUsed =}
+        </QueryClientProvider>
+      </HelmetProvider>
     </React.StrictMode>
   )
 }

--- a/waspc/data/Generator/templates/react-app/src/router.tsx
+++ b/waspc/data/Generator/templates/react-app/src/router.tsx
@@ -1,6 +1,7 @@
 {{={= =}=}}
 import React from 'react'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider, useMatches } from 'react-router-dom'
+import { PageHelmet, type PageHead } from './components/PageHelmet'
 {=# rootComponent.isDefined =}
 {=& rootComponent.importStatement =}
 {=/ rootComponent.isDefined =}
@@ -39,19 +40,31 @@ const userDefinedRoutes = Object.entries(routes).map(([routeKey, route]) => {
   return {
     path: route.to,
     Component: routeNameToRouteComponent[routeKey],
+    handle: { head: (route as { head?: PageHead }).head },
   }
 })
 
-const browserRouter = createBrowserRouter([{
-  path: '/',
-  {=# rootComponent.isDefined =}
-  element: <{= rootComponent.importIdentifier =} />,
-  {=/ rootComponent.isDefined =}
-  ErrorBoundary: DefaultRootErrorBoundary,
-  children: [
-    ...waspDefinedRoutes,
-    ...userDefinedRoutes,
-  ],
-}])
+const browserRouter = createBrowserRouter([
+  {
+    path: '/',
+    {=# rootComponent.isDefined =}
+    element: <{= rootComponent.importIdentifier =} />,
+    {=/ rootComponent.isDefined =}
+    ErrorBoundary: DefaultRootErrorBoundary,
+    children: [
+      ...waspDefinedRoutes,
+      ...userDefinedRoutes,
+    ],
+  },
+])
 
-export const router = <RouterProvider router={browserRouter} />
+export function Router() {
+  const matches = useMatches() as { handle?: { head?: PageHead } }[]
+  const heads = matches.flatMap((m) => (m.handle?.head ? [m.handle.head] : []))
+  return (
+    <>
+      {heads.map((h, i) => (h ? <PageHelmet key={i} {...h} /> : null))}
+      <RouterProvider router={browserRouter} />
+    </>
+  )
+}

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -40,6 +40,7 @@ import Wasp.Generator.WebAppGenerator.DepVersions
     reactQueryVersion,
     reactRouterVersion,
     reactVersion,
+    reactHelmetAsyncVersion,
   )
 import Wasp.Generator.WebAppGenerator.JsImport (extImportToImportJson)
 import Wasp.Generator.WebAppGenerator.RouterGenerator (genRouter)
@@ -134,7 +135,8 @@ npmDepsForWasp _spec =
             -- React and ReactDOM versions should always match.
             ("react-dom", show reactVersion),
             ("@tanstack/react-query", show reactQueryVersion),
-            ("react-router-dom", show reactRouterVersion)
+            ("react-router-dom", show reactRouterVersion),
+            ("react-helmet-async", show reactHelmetAsyncVersion)
           ],
       N.waspDevDependencies =
         Npm.Dependency.fromList
@@ -215,6 +217,7 @@ genSrcDir spec =
       genFileCopy [relfile|components/Loader.module.css|],
       genFileCopy [relfile|components/FullPageWrapper.tsx|],
       genFileCopy [relfile|components/DefaultRootErrorBoundary.tsx|],
+      genFileCopy [relfile|components/PageHelmet.tsx|],
       getIndexTs spec
     ]
     <++> genAuth spec

--- a/waspc/src/Wasp/Generator/WebAppGenerator/DepVersions.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/DepVersions.hs
@@ -5,6 +5,7 @@ module Wasp.Generator.WebAppGenerator.DepVersions
     reactVersion,
     reactTypesVersion,
     viteVersion,
+    reactHelmetAsyncVersion,
   )
 where
 
@@ -27,3 +28,6 @@ reactTypesVersion = SV.backwardsCompatibleWith $ SV.Version 18 0 37 -- follows R
 
 viteVersion :: SV.ComparatorSet
 viteVersion = SV.backwardsCompatibleWith $ SV.Version 4 3 9
+
+reactHelmetAsyncVersion :: SV.ComparatorSet
+reactHelmetAsyncVersion = SV.backwardsCompatibleWith $ SV.Version 1 3 0

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -109,7 +109,8 @@ spec_WebAppGenerator = do
                     (SP.toFilePath Common.webAppSrcDirInWebAppRootDir </>)
                     [ "logo.png",
                       "index.tsx",
-                      "router.tsx"
+                      "router.tsx",
+                      "components/PageHelmet.tsx"
                     ]
                 ]
 


### PR DESCRIPTION
## Summary
- include `react-helmet-async` as a web app dependency
- expose PageHelmet util component
- wrap router with HelmetProvider and allow head data per route
- adapt generator tests

## Testing
- `npm run prettier:check` *(fails: reflect unimplemented AssignableTo)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc6915bc8333a6370947e525a49f