### PR TITLE
Refactor AI modules to support pluggable LLMs

### DIFF
--- a/waspc/src/Wasp/AI/CodeAgent.hs
+++ b/waspc/src/Wasp/AI/CodeAgent.hs
@@ -9,9 +9,8 @@ module Wasp.AI.CodeAgent
     writeNewFile,
     getFile,
     getAllFiles,
-    queryChatGPT,
-    getTotalTokensUsage,
-    getOpenAIApiKey,
+    queryLLM,
+    getTotalTokensUsage
   )
 where
 
@@ -26,28 +25,36 @@ import Data.Text (Text)
 import qualified Network.HTTP.Simple as HTTP
 import System.IO (hPutStrLn, stderr)
 import UnliftIO (Handler (Handler), catches, throwIO)
-import Wasp.AI.OpenAI (OpenAIApiKey)
-import Wasp.AI.OpenAI.ChatGPT (ChatGPTParams (..), ChatMessage, ChatResponse)
-import qualified Wasp.AI.OpenAI.ChatGPT as ChatGPT
+import Wasp.AI.LLM
+  ( ChatMessage,
+    ChatResponse,
+    ChatResponseUsage,
+    LLMProvider (..),
+    getChatResponseContent,
+  )
+import Wasp.AI.OpenAI.ChatGPT (OpenAIProvider, ChatGPTParams)
 import qualified Wasp.Util as Util
 import Wasp.Util.IO.Retry (MonadRetry)
 import qualified Wasp.Util.IO.Retry as R
 import Wasp.Util.Network.HTTP (catchRetryableHttpException)
 import qualified Wasp.Util.Network.HTTP as Utils.HTTP
 
-newtype CodeAgent logMsg a = CodeAgent {_unCodeAgent :: ReaderT (CodeAgentConfig logMsg) (StateT CodeAgentState IO) a}
-  deriving (Monad, Applicative, Functor, MonadIO, MonadReader (CodeAgentConfig logMsg), MonadState CodeAgentState)
+newtype GenericCodeAgent provider logMsg a =
+  GenericCodeAgent {_unCodeAgent :: ReaderT (CodeAgentConfig provider logMsg) (StateT CodeAgentState IO) a}
+  deriving (Monad, Applicative, Functor, MonadIO, MonadReader (CodeAgentConfig provider logMsg), MonadState CodeAgentState)
 
-data CodeAgentConfig logMsg = CodeAgentConfig
-  { _openAIApiKey :: !OpenAIApiKey,
-    _writeFile :: !(FilePath -> Text -> IO ()), -- TODO: Use StrongPath? Not clear which kind of path is it, rel, abs, ... .
+type CodeAgent = GenericCodeAgent OpenAIProvider
+
+data CodeAgentConfig provider logMsg = CodeAgentConfig
+  { _llmProvider :: !provider,
+    _writeFile :: !(FilePath -> Text -> IO ()),
     _writeLog :: !(logMsg -> IO ())
   }
 
-instance MonadRetry (CodeAgent logMsg) where
+instance MonadRetry (GenericCodeAgent provider logMsg) where
   rThreadDelay = liftIO . threadDelay
 
-runCodeAgent :: (IsString logMsg) => CodeAgentConfig logMsg -> CodeAgent logMsg a -> IO a
+runCodeAgent :: (IsString logMsg) => CodeAgentConfig provider logMsg -> GenericCodeAgent provider logMsg a -> IO a
 runCodeAgent config codeAgent =
   (fst <$> (_unCodeAgent codeAgent `runReaderT` config) `runStateT` initialState)
     `catches` [ Handler
@@ -80,41 +87,41 @@ runCodeAgent config codeAgent =
     showShortException :: forall e. Exception e => e -> String
     showShortException = shortenWithEllipsisTo 30 . displayException
 
-writeToLog :: IsString logMsg => logMsg -> CodeAgent logMsg ()
+writeToLog :: IsString logMsg => logMsg -> GenericCodeAgent provider logMsg ()
 writeToLog msg = asks _writeLog >>= \f -> liftIO $ f msg
 
-writeToFile :: FilePath -> (Maybe Text -> Text) -> CodeAgent logMsg ()
+writeToFile :: FilePath -> (Maybe Text -> Text) -> GenericCodeAgent provider logMsg ()
 writeToFile path updateContentFn = do
   content <- updateContentFn <$> getFile path
   asks _writeFile >>= \f -> liftIO $ f path content
   modify $ \s -> s {_files = H.insert path content (_files s)}
 
-writeNewFile :: (FilePath, Text) -> CodeAgent logMsg ()
+writeNewFile :: (FilePath, Text) -> GenericCodeAgent provider logMsg ()
 writeNewFile (path, content) =
   writeToFile path (maybe content $ error $ "file " <> path <> " shouldn't already exist")
 
-getFile :: FilePath -> CodeAgent logMsg (Maybe Text)
+getFile :: FilePath -> GenericCodeAgent provider logMsg (Maybe Text)
 getFile path = gets $ H.lookup path . _files
 
-getAllFiles :: CodeAgent logMsg [(FilePath, Text)]
+getAllFiles :: GenericCodeAgent provider logMsg [(FilePath, Text)]
 getAllFiles = gets $ H.toList . _files
 
-queryChatGPT :: ChatGPTParams -> [ChatMessage] -> CodeAgent logMsg Text
-queryChatGPT params messages = do
-  key <- asks _openAIApiKey
-  chatResponse <- queryChatGPTWithRetry key params messages
-  modify $ \s -> s {_usage = _usage s <> [ChatGPT.usage chatResponse]}
-  return $ ChatGPT.getChatResponseContent chatResponse
+queryLLM :: (LLMProvider provider) => Params provider -> [ChatMessage] -> GenericCodeAgent provider logMsg Text
+queryLLM params messages = do
+  provider <- asks _llmProvider
+  chatResponse <- queryLLMWithRetry provider params messages
+  modify $ \s -> s {_usage = _usage s <> [usage chatResponse]}
+  return $ getChatResponseContent chatResponse
   where
 {- ORMOLU_DISABLE -}
-    queryChatGPTWithRetry :: OpenAIApiKey -> ChatGPTParams -> [ChatMessage] -> CodeAgent logMsg ChatResponse
-    queryChatGPTWithRetry key params' messages' =
+    queryLLMWithRetry :: (LLMProvider provider) => provider -> Params provider -> [ChatMessage] -> GenericCodeAgent provider logMsg ChatResponse
+    queryLLMWithRetry provider' params' messages' =
       do
         R.retry
           (R.expPause $ fromIntegral $ Util.secondsToMicroSeconds 10)
           3
           ( liftIO $
-              (Right <$> ChatGPT.queryChatGPT key params' messages')
+              (Right <$> queryMessages provider' params' messages')
                 `catchRetryableHttpException` ( \e -> do
                     hPutStrLn stderr $ "Caught retryable HTTP exception while doing ChatGPT request: "
                         <> maybe "" (\code -> "Status code: " <> show code <> "; ") (Utils.HTTP.getHttpExceptionStatusCode e)
@@ -125,20 +132,17 @@ queryChatGPT params messages = do
           >>= either throwIO pure
 {- ORMOLU_ENABLE -}
 
-getOpenAIApiKey :: CodeAgent logMsg OpenAIApiKey
-getOpenAIApiKey = asks _openAIApiKey
-
 type NumTokens = Int
 
 -- | Returns total tokens usage: (<num_prompt_tokens>, <num_completion_tokens>).
-getTotalTokensUsage :: CodeAgent logMsg (NumTokens, NumTokens)
+getTotalTokensUsage :: GenericCodeAgent provider logMsg (NumTokens, NumTokens)
 getTotalTokensUsage = do
   usage <- gets _usage
-  let numPromptTokens = sum $ ChatGPT.prompt_tokens <$> usage
-  let numCompletionTokens = sum $ ChatGPT.completion_tokens <$> usage
+  let numPromptTokens = sum $ prompt_tokens <$> usage
+  let numCompletionTokens = sum $ completion_tokens <$> usage
   return (numPromptTokens, numCompletionTokens)
 
 data CodeAgentState = CodeAgentState
   { _files :: !(H.HashMap FilePath Text), -- TODO: Name this "cacheFiles" maybe?
-    _usage :: ![ChatGPT.ChatResponseUsage]
+    _usage :: ![ChatResponseUsage]
   }

--- a/waspc/src/Wasp/AI/GenerateNewProject/Operation.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Operation.hs
@@ -28,7 +28,7 @@ import Wasp.AI.GenerateNewProject.Common
     NewProjectDetails (..),
     codingChatGPTParams,
     fixingChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
     writeToWaspFileEnd,
   )
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionStartMarkerLine)
@@ -36,7 +36,7 @@ import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Entity (entityPlanToPrismaModelText)
 import Wasp.AI.GenerateNewProject.Plan (Plan)
 import qualified Wasp.AI.GenerateNewProject.Plan as Plan
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 import qualified Wasp.Analyzer.Parser as P
 import qualified Wasp.Util.Aeson as Util.Aeson
 
@@ -51,7 +51,7 @@ generateAndWriteOperation operationType newProjectDetails waspFilePath plan oper
 generateOperation :: OperationType -> NewProjectDetails -> [Plan.Entity] -> Plan.Operation -> CodeAgent Operation
 generateOperation operationType newProjectDetails entityPlans operationPlan = do
   impl <-
-    queryChatGPTForJSON (codingChatGPTParams newProjectDetails) chatMessages
+    queryLLMForJSON (codingChatGPTParams newProjectDetails) chatMessages
       >>= fixOperationImplIfNeeded
   return Operation {opImpl = impl, opPlan = operationPlan, opType = operationType}
   where
@@ -129,7 +129,7 @@ generateOperation operationType newProjectDetails entityPlans operationPlan = do
         then return operationImpl
         else do
           let issuesText = T.pack $ intercalate "\n" ((" - " <>) <$> issues)
-          queryChatGPTForJSON (fixingChatGPTParams $ codingChatGPTParams newProjectDetails) $
+          queryLLMForJSON (fixingChatGPTParams $ codingChatGPTParams newProjectDetails) $
             chatMessages
               <> [ ChatMessage {role = Assistant, content = Util.Aeson.encodeToText operationImpl},
                    ChatMessage

--- a/waspc/src/Wasp/AI/GenerateNewProject/OperationsJsFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/OperationsJsFile.hs
@@ -18,12 +18,12 @@ import Wasp.AI.GenerateNewProject.Common
     NewProjectDetails,
     codingChatGPTParams,
     fixingChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
   )
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionBlock)
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Operation (actionDocPrompt, queryDocPrompt)
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 
 fixOperationsJsFile :: NewProjectDetails -> FilePath -> FilePath -> CodeAgent ()
 fixOperationsJsFile newProjectDetails waspFilePath opJsFilePath = do
@@ -33,7 +33,7 @@ fixOperationsJsFile newProjectDetails waspFilePath opJsFilePath = do
   --   For that however, we would likely need the whole Wasp file generated on the disk,
   --   with npm dependencies installed, so we skipped it for now.
   fixedOpJsFile <-
-    queryChatGPTForJSON
+    queryLLMForJSON
       (fixingChatGPTParams $ codingChatGPTParams newProjectDetails)
       [ ChatMessage {role = System, content = Prompts.systemPrompt},
         ChatMessage {role = User, content = fixOpJsFilePrompt currentWaspFileContent currentOpJsFileContent}

--- a/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
@@ -22,14 +22,14 @@ import Wasp.AI.GenerateNewProject.Common
   ( CodeAgent,
     NewProjectDetails (..),
     codingChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
     writeToWaspFileEnd,
   )
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Entity (entityPlanToPrismaModelText)
 import Wasp.AI.GenerateNewProject.Operation (Operation (opImpl, opPlan), OperationImpl (opJsImpl))
 import qualified Wasp.AI.GenerateNewProject.Plan as Plan
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 
 generateAndWritePage ::
   NewProjectDetails -> FilePath -> [Plan.Entity] -> [Operation] -> [Operation] -> Plan.Page -> CodeAgent Page
@@ -42,7 +42,7 @@ generateAndWritePage newProjectDetails waspFilePath entityPlans queries actions 
 
 generatePage :: NewProjectDetails -> [Plan.Entity] -> [Operation] -> [Operation] -> Plan.Page -> CodeAgent Page
 generatePage newProjectDetails entityPlans queries actions pPlan = do
-  impl <- queryChatGPTForJSON (codingChatGPTParams newProjectDetails) chatMessages
+  impl <- queryLLMForJSON (codingChatGPTParams newProjectDetails) chatMessages
   return Page {pageImpl = impl, pagePlan = pPlan}
   where
     chatMessages =

--- a/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
@@ -17,19 +17,19 @@ import Wasp.AI.GenerateNewProject.Common
     NewProjectDetails (..),
     codingChatGPTParams,
     fixingChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
   )
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionBlock)
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Page (makePageDocPrompt)
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 
 fixPageComponent :: NewProjectDetails -> FilePath -> FilePath -> CodeAgent ()
 fixPageComponent newProjectDetails waspFilePath pageComponentPath = do
   currentWaspFileContent <- fromMaybe (error "couldn't find wasp file") <$> getFile waspFilePath
   currentPageComponentContent <- fromMaybe (error "couldn't find page file to fix") <$> getFile pageComponentPath
   fixedPageComponent <-
-    queryChatGPTForJSON
+    queryLLMForJSON
       (fixingChatGPTParams $ codingChatGPTParams newProjectDetails)
       [ ChatMessage {role = System, content = Prompts.systemPrompt},
         ChatMessage {role = User, content = fixPageComponentPrompt currentWaspFileContent currentPageComponentContent}

--- a/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
@@ -27,12 +27,12 @@ import Wasp.AI.GenerateNewProject.Common
     NewProjectDetails (..),
     fixingChatGPTParams,
     planningChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
   )
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionBlock)
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import qualified Wasp.AI.GenerateNewProject.LogMsg as L
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 import qualified Wasp.Psl.Format as Prisma
 import qualified Wasp.Psl.Parser.Model as Psl.Parser.Model
 import qualified Wasp.Util.Aeson as Util.Aeson
@@ -46,7 +46,7 @@ generatePlan newProjectDetails planRules = do
   writeToLog $
     "\n" <> L.styled L.Generating "Generating" <> " plan (slowest step, can take up to 90 seconds for slower models)"
       <> L.styled (L.Custom [Term.Blink]) "..."
-  initialPlan <- queryChatGPTForJSON (planningChatGPTParams newProjectDetails) chatMessages
+  initialPlan <- queryLLMForJSON (planningChatGPTParams newProjectDetails) chatMessages
   writeToLog $ "Initial plan generated!\n" <> L.fromText (summarizePlan initialPlan)
   writeToLog $ L.styled L.Fixing "Fixing" <> " initial plan..."
   fixedPlan <- fixPlanRepeatedly 3 initialPlan
@@ -178,7 +178,7 @@ generatePlan newProjectDetails planRules = do
                     |]
           writeToLog "Sending plan to GPT for fixing..."
           fixedPlan <-
-            queryChatGPTForJSON (fixingChatGPTParams $ planningChatGPTParams newProjectDetails) $
+            queryLLMForJSON (fixingChatGPTParams $ planningChatGPTParams newProjectDetails) $
               chatMessages
                 <> [ ChatMessage {role = Assistant, content = Util.Aeson.encodeToText plan'},
                      ChatMessage

--- a/waspc/src/Wasp/AI/GenerateNewProject/PrismaFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/PrismaFile.hs
@@ -17,12 +17,12 @@ import Wasp.AI.GenerateNewProject.Common
     NewProjectDetails,
     codingChatGPTParams,
     fixingChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
   )
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionBlock)
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Plan (Plan)
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 import Wasp.Psl.Format (PrismaFormatResult (..))
 import qualified Wasp.Psl.Format as Prisma
 import qualified Wasp.Util.Aeson as Utils.Aeson
@@ -42,7 +42,7 @@ fixPrismaFile newProjectDetails prismaFilePath plan = do
       case prismaFormatResult of
         PrismaFormatResult {_schemaErrors = Nothing} -> return $ FileContent {fileContent = prismaFileContent}
         PrismaFormatResult {_schemaErrors = Just schemaErrors} ->
-          queryChatGPTForJSON
+          queryLLMForJSON
             (fixingChatGPTParams $ codingChatGPTParams newProjectDetails)
             [ ChatMessage {role = System, content = Prompts.systemPrompt},
               ChatMessage {role = User, content = fixPrismaFilePrompt prismaFileContent schemaErrors}

--- a/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
@@ -17,12 +17,12 @@ import Wasp.AI.GenerateNewProject.Common
     NewProjectDetails,
     codingChatGPTParams,
     fixingChatGPTParams,
-    queryChatGPTForJSON,
+    queryLLMForJSON,
   )
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionBlock)
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Plan (Plan)
-import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.AI.LLM (ChatMessage (..), ChatRole (..))
 import Wasp.Analyzer.Parser.Ctx (Ctx (..))
 import Wasp.Project.WaspFile.WaspLang (analyzeWaspFileContent)
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
@@ -49,7 +49,7 @@ fixWaspFile newProjectDetails waspFilePath plan = do
       case shouldContinueIfCompileErrors of
         OnlyIfCompileErrors | null compileErrors -> return $ FileContent {fileContent = wfContent}
         _otherwise ->
-          queryChatGPTForJSON
+          queryLLMForJSON
             (fixingChatGPTParams $ codingChatGPTParams newProjectDetails)
             [ ChatMessage {role = System, content = Prompts.systemPrompt},
               ChatMessage {role = User, content = fixWaspFilePrompt wfContent compileErrors}

--- a/waspc/src/Wasp/AI/LLM.hs
+++ b/waspc/src/Wasp/AI/LLM.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Generic low level interface for Large Language Models.
+--   Contains provider neutral data types and a typeclass
+--   describing minimal operations used by Wasp.
+module Wasp.AI.LLM
+  ( ChatMessage (..)
+  , ChatRole (..)
+  , ChatResponse (..)
+  , ChatResponseUsage (..)
+  , ChatResponseChoice (..)
+  , getChatResponseContent
+  , LLMProvider (..)
+  ) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.Aeson as Aeson
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+-- | Single message exchanged with LLM.
+data ChatMessage = ChatMessage
+  { role :: !ChatRole
+  , content :: !Text
+  }
+  deriving (Generic, Show, ToJSON, FromJSON)
+
+-- | Role of the chat participant.
+data ChatRole = User | System | Assistant
+  deriving (Generic, Show)
+
+instance ToJSON ChatRole where
+  toJSON User = Aeson.String "user"
+  toJSON System = Aeson.String "system"
+  toJSON Assistant = Aeson.String "assistant"
+
+instance FromJSON ChatRole where
+  parseJSON = Aeson.withText "ChatRole" $ \case
+    "user" -> pure User
+    "system" -> pure System
+    "assistant" -> pure Assistant
+    other -> fail $ "Invalid ChatRole: " <> show other
+
+-- | Response returned by an LLM.
+data ChatResponse = ChatResponse
+  { id :: !String
+  , object :: !String
+  , created :: !Int
+  , model :: !String
+  , choices :: ![ChatResponseChoice]
+  , usage :: !ChatResponseUsage
+  }
+  deriving (Generic, Show, FromJSON)
+
+-- | Usage statistics returned by the provider.
+data ChatResponseUsage = ChatResponseUsage
+  { prompt_tokens :: !Int
+  , completion_tokens :: !Int
+  , total_tokens :: !Int
+  }
+  deriving (Generic, Show, FromJSON)
+
+-- | Single choice within a response.
+data ChatResponseChoice = ChatResponseChoice
+  { index :: !Int
+  , message :: !ChatMessage
+  , finish_reason :: !String
+  }
+  deriving (Generic, Show, FromJSON)
+
+-- | Extracts assistant content from a response.
+getChatResponseContent :: ChatResponse -> Text
+getChatResponseContent = content . message . head . choices
+
+-- | Abstraction over concrete LLM providers.
+class LLMProvider p where
+  -- | Parameters used when querying the provider.
+  type Params p
+  -- | Perform a query with given parameters and messages.
+  queryMessages :: p -> Params p -> [ChatMessage] -> IO ChatResponse


### PR DESCRIPTION
## Summary
- introduce `Wasp.AI.LLM` with provider‑neutral chat types and `LLMProvider`
- implement `OpenAIProvider` instance and adapt `CodeAgent` for generic LLMs
- refactor generator modules to query the provider via new interface
- default behaviour still uses OpenAI

## Testing
- `cabal test waspc-test --test-show-details=streaming` *(fails: Cannot find program 'ghc-8.10.7')*

------
https://chatgpt.com/codex/tasks/task_e_686e53b549e48333a2ce30f568614945