### PR TITLE
Add provider option for 'wasp new'

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -18,6 +18,7 @@ import Wasp.Cli.Command.Clean (clean)
 import Wasp.Cli.Command.Compile (compile)
 import Wasp.Cli.Command.CreateNewProject (createNewProject)
 import qualified Wasp.Cli.Command.CreateNewProject.AI as Command.CreateNewProject.AI
+import qualified Wasp.AI.Provider as Provider
 import Wasp.Cli.Command.Db (runCommandThatRequiresDbRunning)
 import qualified Wasp.Cli.Command.Db.Migrate as Command.Db.Migrate
 import qualified Wasp.Cli.Command.Db.Reset as Command.Db.Reset
@@ -91,12 +92,14 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
       ["--stdout", projectName, appDescription, projectConfigJson] ->
         runCommand $
           Command.CreateNewProject.AI.createNewProjectNonInteractiveToStdout
+            Provider.OpenAI
             projectName
             appDescription
             projectConfigJson
       [projectName, appDescription, projectConfigJson] ->
         runCommand $
           Command.CreateNewProject.AI.createNewProjectNonInteractiveOnDisk
+            Provider.OpenAI
             projectName
             appDescription
             projectConfigJson

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ArgumentsParser.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ArgumentsParser.hs
@@ -10,7 +10,8 @@ import Wasp.Cli.Command.Call (Arguments)
 
 data NewProjectArgs = NewProjectArgs
   { _projectName :: Maybe String,
-    _templateName :: Maybe String
+    _templateName :: Maybe String,
+    _provider :: Maybe String
   }
 
 parseNewProjectArgs :: Arguments -> Either String NewProjectArgs
@@ -24,6 +25,7 @@ parseNewProjectArgs newArgs = parserResultToEither $ execParserPure defaultPrefs
       NewProjectArgs
         <$> Opt.optional projectNameParser
         <*> Opt.optional templateNameParser
+        <*> Opt.optional providerParser
 
     projectNameParser :: Opt.Parser String
     projectNameParser = Opt.strArgument $ Opt.metavar "PROJECT_NAME"
@@ -35,6 +37,15 @@ parseNewProjectArgs newArgs = parserResultToEither $ execParserPure defaultPrefs
           <> Opt.short 't'
           <> Opt.metavar "TEMPLATE_NAME"
           <> Opt.help "Template to use for the new project"
+
+    providerParser :: Opt.Parser String
+    providerParser =
+      Opt.strOption $
+        Opt.long "provider"
+          <> Opt.metavar "PROVIDER"
+          <> Opt.value "openai"
+          <> Opt.showDefault
+          <> Opt.help "LLM provider for AI project generation"
 
     parserResultToEither :: Opt.ParserResult NewProjectArgs -> Either String NewProjectArgs
     parserResultToEither (Opt.Success success) = Right success

--- a/waspc/src/Wasp/AI/Provider.hs
+++ b/waspc/src/Wasp/AI/Provider.hs
@@ -1,0 +1,49 @@
+module Wasp.AI.Provider
+  ( Provider(..)
+  , ApiKey
+  , providerEnvVar
+  , getProviderApiKey
+  ) where
+
+import Control.Monad.Except (throwError)
+import Control.Monad.IO.Class (liftIO)
+import Data.Functor ((<&>))
+import System.Environment (lookupEnv)
+
+import Wasp.Cli.Command (Command, CommandError (..))
+
+-- | Supported AI providers.
+data Provider = OpenAI deriving (Show, Eq)
+
+-- | API key used for querying the provider.
+type ApiKey = String
+
+-- | Returns the name of the env variable expected to hold the API key.
+providerEnvVar :: Provider -> String
+providerEnvVar OpenAI = "OPENAI_API_KEY"
+
+-- | Retrieves API key for given provider from environment.
+getProviderApiKey :: Provider -> Command ApiKey
+getProviderApiKey provider =
+  liftIO (lookupEnv envVar <&> (>>= validateKey)) >>= maybe throwMissingEnvVar pure
+  where
+    envVar = providerEnvVar provider
+
+    validateKey "" = Nothing
+    validateKey k = Just k
+
+    throwMissingEnvVar = throwError $ CommandError ("Missing " ++ envVar ++ " environment variable") message
+
+    message = unlines $ case provider of
+      OpenAI ->
+        [ "Wasp AI uses ChatGPT to generate your project and therefore requires an OpenAI API key.",
+          "You can obtain this key via your OpenAI account settings: https://platform.openai.com/account/api-keys.",
+          "Then, set " ++ envVar ++ " env var to it and Wasp CLI will read from it.",
+          "",
+          "To persist the " ++ envVar ++ " env var, add",
+          "  export " ++ envVar ++ "=<yourkeyhere>",
+          "to your shell profile and restart the terminal.",
+          "",
+          "Alternatively, you can go to our Mage web app at https://usemage.ai and generate a new Wasp app there for free."
+        ]
+

--- a/waspc/test/Cli/CreateNewProjectArgumentsParserTest.hs
+++ b/waspc/test/Cli/CreateNewProjectArgumentsParserTest.hs
@@ -1,0 +1,15 @@
+module Cli.CreateNewProjectArgumentsParserTest where
+
+import Test.Tasty.Hspec
+import Wasp.Cli.Command.CreateNewProject.ArgumentsParser (parseNewProjectArgs, NewProjectArgs(..))
+
+spec_Cli_CreateNewProjectArgumentsParser :: Spec
+spec_Cli_CreateNewProjectArgumentsParser =
+  describe "parseNewProjectArgs" $ do
+    it "parses provider option" $ do
+      parseNewProjectArgs ["myapp", "--provider", "openai"]
+        `shouldBe` Right (NewProjectArgs (Just "myapp") Nothing (Just "openai"))
+    it "uses default provider when none specified" $ do
+      parseNewProjectArgs ["myapp"]
+        `shouldBe` Right (NewProjectArgs (Just "myapp") Nothing Nothing)
+

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -177,6 +177,7 @@ library
     Wasp.AI.GenerateNewProject.PrismaFile
     Wasp.AI.OpenAI
     Wasp.AI.OpenAI.ChatGPT
+    Wasp.AI.Provider
     Wasp.Analyzer
     Wasp.Analyzer.AnalyzeError
     Wasp.Analyzer.ErrorMessage

--- a/web/docs/wasp-ai/creating-new-app.md
+++ b/web/docs/wasp-ai/creating-new-app.md
@@ -13,7 +13,7 @@ Wasp AI allows you to create a new Wasp app **from only a title and a short desc
 There are two main ways to create a new Wasp app with Wasp AI:
 
 1. Free, open-source online app [usemage.ai](https://usemage.ai).
-2. Running `wasp new` on your machine and picking AI generation. For this you need to provide your own OpenAI API keys, but it allows for more flexibility (choosing GPT models).
+2. Running `wasp new` on your machine and picking AI generation. For this you need to provide your own API keys for the chosen provider (e.g. OpenAI), but it allows for more flexibility (choosing GPT models).
 
 They both use the same logic in the background, so both approaches are equally "smart", the difference is just in the UI / settings.
 
@@ -35,9 +35,9 @@ If you want to know more, check this [blog post](/blog/2023/07/10/gpt-web-app-ge
 
 ## Wasp CLI
 
-You can create a new Wasp app using Wasp AI by running `wasp new` in your terminal and picking AI generation.
+You can create a new Wasp app using Wasp AI by running `wasp new` in your terminal and picking AI generation. Use the `--provider` option to select the LLM provider (defaults to `openai`).
 
-If you don't have them set yet, `wasp` will ask you to provide (via ENV vars) your OpenAI API keys (which it will use to query GPT).
+If you don't have them set yet, `wasp` will ask you to provide (via ENV vars) the API keys for the selected provider (which it will use to query GPT).
 
 Then, after providing a title and description for your Wasp app, the new app will be generated on your disk!
 

--- a/web/versioned_docs/version-0.15.0/wasp-ai/creating-new-app.md
+++ b/web/versioned_docs/version-0.15.0/wasp-ai/creating-new-app.md
@@ -13,7 +13,7 @@ Wasp AI allows you to create a new Wasp app **from only a title and a short desc
 There are two main ways to create a new Wasp app with Wasp AI:
 
 1. Free, open-source online app [usemage.ai](https://usemage.ai).
-2. Running `wasp new` on your machine and picking AI generation. For this you need to provide your own OpenAI API keys, but it allows for more flexibility (choosing GPT models).
+2. Running `wasp new` on your machine and picking AI generation. For this you need to provide your own API keys for the chosen provider (e.g. OpenAI), but it allows for more flexibility (choosing GPT models).
 
 They both use the same logic in the background, so both approaches are equally "smart", the difference is just in the UI / settings.
 
@@ -35,9 +35,9 @@ If you want to know more, check this [blog post](/blog/2023/07/10/gpt-web-app-ge
 
 ## Wasp CLI
 
-You can create a new Wasp app using Wasp AI by running `wasp new` in your terminal and picking AI generation.
+You can create a new Wasp app using Wasp AI by running `wasp new` in your terminal and picking AI generation. Use the `--provider` option to select the LLM provider (defaults to `openai`).
 
-If you don't have them set yet, `wasp` will ask you to provide (via ENV vars) your OpenAI API keys (which it will use to query GPT).
+If you don't have them set yet, `wasp` will ask you to provide (via ENV vars) the API keys for the selected provider (which it will use to query GPT).
 
 Then, after providing a title and description for your Wasp app, the new app will be generated on your disk!
 


### PR DESCRIPTION
## Summary
- add new AI provider module and generic API key retrieval
- extend `wasp new` argument parser with `--provider`
- pass provider into project creation logic
- default `new:ai` command to OpenAI provider
- document provider usage
- add unit tests for argument parser

## Testing
- `./waspc/run test` *(fails: cabal not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5e9c5dc88333ac62fd0ca64e2766