### PR TITLE
Add RootApplication module with tests

### DIFF
--- a/gui/App.cabal
+++ b/gui/App.cabal
@@ -23,6 +23,7 @@ cabal-version:       >=1.10
 executable App
   main-is:             Main.hs
   -- other-modules:
+        RootApplication
   -- other-extensions:
   build-depends:
   	ihp,
@@ -69,3 +70,19 @@ executable App
     , PartialTypeSignatures
     , StandaloneDeriving
     , DerivingVia
+
+test-suite gui-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: Test
+  main-is: Main.hs
+  build-tool-depends:
+    tasty-discover:tasty-discover
+  build-depends:
+    , base
+    , ihp
+    , wai
+    , text
+    , hspec
+  other-modules:
+    RootApplication
+  default-language: Haskell2010

--- a/gui/Main.hs
+++ b/gui/Main.hs
@@ -2,6 +2,7 @@ module Main where
 import IHP.Prelude
 
 import Config
+import RootApplication
 import qualified IHP.Server
 import IHP.RouterSupport
 import IHP.FrameworkConfig

--- a/gui/RootApplication.hs
+++ b/gui/RootApplication.hs
@@ -1,0 +1,8 @@
+module RootApplication
+    ( RootApplication(..)
+    ) where
+
+-- | Marker type for the IHP application.
+--   Exported so other modules can reference it.
+data RootApplication = RootApplication
+    deriving (Eq, Show)

--- a/gui/Test/Main.hs
+++ b/gui/Test/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --modules=*Test.hs #-}

--- a/gui/Test/RootApplicationTest.hs
+++ b/gui/Test/RootApplicationTest.hs
@@ -1,0 +1,9 @@
+module RootApplicationTest where
+
+import Test.Tasty.Hspec
+import RootApplication
+
+spec_rootApplication :: Spec
+spec_rootApplication = describe "RootApplication" $ do
+    it "derives Eq" $ RootApplication `shouldBe` RootApplication
+    it "derives Show" $ show RootApplication `shouldBe` "RootApplication"

--- a/gui/flake.nix
+++ b/gui/flake.nix
@@ -22,15 +22,13 @@
                         # Native dependencies, e.g. imagemagick
                     ];
                     haskellPackages = p: with p; [
-                        # Haskell dependencies go here
+                        -- Haskell dependencies go here
                         p.ihp
                         cabal-install
                         base
                         wai
                         text
-
-                        # Uncomment on local development for testing
-                        # hspec
+                        hspec
                     ];
                 };
 


### PR DESCRIPTION
## Summary
- introduce `RootApplication` data type in new module
- use `RootApplication` in `Main.hs`
- expose new module via `App.cabal` and `flake.nix`
- provide minimal test suite with tasty-discover

## Testing
- `runghc` *failed*: `bash: runghc: command not found`


------
https://chatgpt.com/codex/tasks/task_e_68705954dee08333bc6425755fb49f9b