### PR TITLE
Add asynchronous CLI endpoint and UI integration

### DIFF
--- a/frontend/components/CliRunner.tsx
+++ b/frontend/components/CliRunner.tsx
@@ -1,0 +1,15 @@
+import { useState } from "react";
+import useCli from "../hooks/useCli";
+
+export default function CliRunner() {
+  const { jobId, run } = useCli();
+  const [cmd, setCmd] = useState("");
+
+  return (
+    <div>
+      <input value={cmd} onChange={(e) => setCmd(e.target.value)} />
+      <button onClick={() => run(cmd)}>Run</button>
+      {jobId && <p>Job started: {jobId}</p>}
+    </div>
+  );
+}

--- a/frontend/hooks/useCli.ts
+++ b/frontend/hooks/useCli.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+export interface CliResult {
+  jobId: string;
+}
+
+export default function useCli() {
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  const run = (cmd: string) =>
+    fetch(`/Cli?cmd=${encodeURIComponent(cmd)}`)
+      .then((res) => res.json())
+      .then((data: CliResult) => setJobId(data.jobId));
+
+  return { jobId, run };
+}

--- a/frontend/pages/cli.tsx
+++ b/frontend/pages/cli.tsx
@@ -1,0 +1,5 @@
+import CliRunner from "../components/CliRunner";
+
+export default function CliPage() {
+  return <CliRunner />;
+}

--- a/gui/Application/Controller/CliController.hs
+++ b/gui/Application/Controller/CliController.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Application.Controller.CliController where
+
+import Application.Controller.Prelude
+import Application.Service.CliService (runCliCommand)
+import Data.Aeson (object, (.=))
+
+instance Controller CliController where
+    action CliAction = do
+        cmd <- param @Text "cmd"
+        jobId <- liftIO $ runCliCommand cmd
+        renderJson $ object ["jobId" .= jobId]
+
+-- | Controller for running CLI commands.
+data CliController = CliAction deriving (Eq, Show)

--- a/gui/Application/Controller/Prelude.hs
+++ b/gui/Application/Controller/Prelude.hs
@@ -5,3 +5,4 @@ import Application.Helper.Controller as X
 import Application.Service.UserService as X
 import Application.Service.PostService as X
 import Application.Service.CliRunService as X
+import Application.Service.CliService as X

--- a/gui/Application/Service/CliService.hs
+++ b/gui/Application/Service/CliService.hs
@@ -1,0 +1,15 @@
+module Application.Service.CliService where
+
+import IHP.Prelude
+import qualified System.Process as Process
+import Control.Concurrent.Async (async)
+import Data.UUID (UUID)
+import qualified Data.UUID.V4 as UUID
+
+-- | Runs a CLI command asynchronously. Returns a job identifier.
+runCliCommand :: Text -> IO UUID
+runCliCommand cmd = do
+    jobId <- UUID.nextRandom
+    -- Run the command asynchronously to avoid blocking the controller.
+    _ <- async (Process.callCommand (cs cmd))
+    pure jobId

--- a/gui/Main.hs
+++ b/gui/Main.hs
@@ -10,6 +10,7 @@ import IHP.Job.Types
 import Application.Controller.UsersController
 import Application.Controller.PostsController
 import Application.Controller.CliRunsController
+import Application.Controller.CliController
 
 instance FrontController RootApplication where
     controllers =
@@ -17,6 +18,7 @@ instance FrontController RootApplication where
           , parseRoute @"/Posts" PostsAction
           , parseRoute @"/Users" UsersAction
           , parseRoute @"/CliRuns" CliRunsAction
+          , parseRoute @"/Cli" CliAction
           , parseRoute @"/Users.json" UsersJsonAction
           , parseRoute @"/Posts.json" PostsJsonAction
           , parseRoute @"/CliRuns.json" CliRunsJsonAction

--- a/gui/RootApplication.hs
+++ b/gui/RootApplication.hs
@@ -2,6 +2,7 @@ module RootApplication
     ( RootApplication(..)
     ) where
 
+import Application.Controller.CliController ()
 -- | Marker type for the IHP application.
 --   Exported so other modules can reference it.
 data RootApplication = RootApplication


### PR DESCRIPTION
## Summary
- add asynchronous CLI command service
- expose `/Cli` route via `CliController` returning JSON job id
- provide frontend hook, component, and page to run CLI commands

## Testing
- `npm run prettier:check` *(fails: Code style issues found in 19 files. Run Prettier with --write to fix.)*
- `npx prettier frontend/hooks/useCli.ts frontend/components/CliRunner.tsx frontend/pages/cli.tsx --check`
- `cd frontend && npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688d4de0eb5c83338fa7e341e3f3fc70