### PR TITLE
Add CLI run detail views and API

### DIFF
--- a/frontend/__tests__/CliRunList.test.tsx
+++ b/frontend/__tests__/CliRunList.test.tsx
@@ -17,5 +17,7 @@ jest.mock("../hooks/useCliRuns", () => () => ({
 
 test("renders cli runs", () => {
   render(<CliRunList />);
-  expect(screen.getByText(/echo hi/)).toBeInTheDocument();
+  const link = screen.getByRole("link", { name: /echo hi/ });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute("href", "/cli-runs/1");
 });

--- a/frontend/components/CliRunDetail.tsx
+++ b/frontend/components/CliRunDetail.tsx
@@ -1,0 +1,23 @@
+import useCliRun from "../hooks/useCliRun";
+
+interface Props {
+  id: string;
+}
+
+export default function CliRunDetail({ id }: Props) {
+  const { run } = useCliRun(id);
+  if (!run) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2>
+        <code>{run.command} {run.args.join(" ")}</code>
+      </h2>
+      <p>Exit code: {run.exitCode}</p>
+      <h3>Stdout</h3>
+      <pre>{run.stdout}</pre>
+      <h3>Stderr</h3>
+      <pre>{run.stderr}</pre>
+    </div>
+  );
+}

--- a/frontend/components/CliRunList.tsx
+++ b/frontend/components/CliRunList.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import useCliRuns from "../hooks/useCliRuns";
 
 export default function CliRunList() {
@@ -6,10 +7,11 @@ export default function CliRunList() {
     <ul>
       {runs.map((r) => (
         <li key={r.id}>
-          <code>
-            {r.command} {r.args.join(" ")}
-          </code>{" "}
-          → {r.exitCode}
+          <Link href={`/cli-runs/${r.id}`}>
+            <code>
+              {r.command} {r.args.join(" ")}
+            </code>
+          </Link>{" "}→ {r.exitCode}
         </li>
       ))}
     </ul>

--- a/frontend/hooks/useCliRun.ts
+++ b/frontend/hooks/useCliRun.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+import { CliRun } from "../lib/cliRunStore";
+
+export default function useCliRun(id: string) {
+  const [run, setRun] = useState<CliRun | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/cli-runs/${id}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setRun(data));
+  }, [id]);
+
+  return { run };
+}

--- a/frontend/lib/cliRunStore.ts
+++ b/frontend/lib/cliRunStore.ts
@@ -32,6 +32,11 @@ export async function listRuns(): Promise<CliRun[]> {
   return readFile();
 }
 
+export async function getRun(id: string): Promise<CliRun | undefined> {
+  const runs = await readFile();
+  return runs.find((r) => r.id === id);
+}
+
 export async function recordRun(data: {
   command: string;
   args: string[];

--- a/frontend/pages/api/cli-runs/[id].ts
+++ b/frontend/pages/api/cli-runs/[id].ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getRun } from "../../../services/cliService";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    res.status(405).end();
+    return;
+  }
+  const { id } = req.query;
+  const run = typeof id === "string" ? await getRun(id) : null;
+  if (!run) {
+    res.status(404).end();
+    return;
+  }
+  res.status(200).json(run);
+}

--- a/frontend/pages/cli-runs/[id].tsx
+++ b/frontend/pages/cli-runs/[id].tsx
@@ -1,0 +1,9 @@
+import { useRouter } from "next/router";
+import CliRunDetail from "../../components/CliRunDetail";
+
+export default function CliRunPage() {
+  const { query } = useRouter();
+  const id = typeof query.id === "string" ? query.id : "";
+  if (!id) return null;
+  return <CliRunDetail id={id} />;
+}

--- a/frontend/services/cliService.ts
+++ b/frontend/services/cliService.ts
@@ -1,4 +1,4 @@
-import { CliRun, listRuns, recordRun } from "../lib/cliRunStore";
+import { CliRun, getRun as fetchRun, listRuns, recordRun } from "../lib/cliRunStore";
 import { runCommand } from "../lib/runCommand";
 
 export interface CommandSpec {
@@ -24,4 +24,8 @@ export async function executeCommand({ command, args }: CommandSpec): Promise<Cl
 
 export async function getRuns(): Promise<CliRun[]> {
   return listRuns();
+}
+
+export async function getRun(id: string): Promise<CliRun | undefined> {
+  return fetchRun(id);
 }

--- a/gui/Application/Controller/CliRunsController.hs
+++ b/gui/Application/Controller/CliRunsController.hs
@@ -3,6 +3,8 @@ module Application.Controller.CliRunsController where
 
 import Application.Controller.Prelude
 import Application.View.CliRuns.Index
+import Application.View.CliRuns.Show
+import Data.UUID (UUID)
 
 instance Controller CliRunsController where
     action CliRunsAction = do
@@ -13,7 +15,21 @@ instance Controller CliRunsController where
         cliRuns <- liftIO listCliRuns
         renderJson cliRuns
 
+    action ShowCliRunAction { cliRunId } = do
+        maybeRun <- liftIO $ findCliRun cliRunId
+        case maybeRun of
+            Just cliRun -> render ShowView { .. }
+            Nothing -> renderPlain "Run not found"
+
+    action ShowCliRunJsonAction { cliRunId } = do
+        maybeRun <- liftIO $ findCliRun cliRunId
+        case maybeRun of
+            Just cliRun -> renderJson cliRun
+            Nothing -> renderNotFound
+
 data CliRunsController
     = CliRunsAction
     | CliRunsJsonAction
+    | ShowCliRunAction { cliRunId :: UUID }
+    | ShowCliRunJsonAction { cliRunId :: UUID }
     deriving (Eq, Show)

--- a/gui/Application/Service/CliRunService.hs
+++ b/gui/Application/Service/CliRunService.hs
@@ -1,13 +1,27 @@
 module Application.Service.CliRunService where
 
-import Generated.Types
+import Data.Aeson (eitherDecodeFileStrict')
+import Data.List (find)
 import Data.UUID (UUID)
+import Generated.Types
+import System.Directory (doesFileExist)
+
+cliRunsFile :: FilePath
+cliRunsFile = "../frontend/data/cli-runs.json"
 
 listCliRuns :: IO [CliRun]
-listCliRuns = pure []
+listCliRuns = do
+    exists <- doesFileExist cliRunsFile
+    if exists
+        then do
+            result <- eitherDecodeFileStrict' cliRunsFile
+            pure $ either (const []) id result
+        else pure []
 
 findCliRun :: UUID -> IO (Maybe CliRun)
-findCliRun _ = pure Nothing
+findCliRun runId = do
+    runs <- listCliRuns
+    pure $ find ((== runId) . cliRunId) runs
 
 createCliRun :: CliRun -> IO ()
 createCliRun _ = pure ()

--- a/gui/Application/View/CliRuns/Index.hs
+++ b/gui/Application/View/CliRuns/Index.hs
@@ -1,8 +1,25 @@
 module Application.View.CliRuns.Index where
 
 import Application.View.Prelude
+import Application.Controller.CliRunsController (CliRunsController (ShowCliRunAction))
 
 data IndexView = IndexView { cliRuns :: [CliRun] }
 
 instance View IndexView where
-    html IndexView { .. } = layout [hsx|<h1>Cli Runs</h1>|]
+    html IndexView { .. } =
+        layout
+            [hsx|
+                <h1>Cli Runs</h1>
+                <ul>
+                    {forEach cliRuns renderRun}
+                </ul>
+            |]
+      where
+        renderRun run =
+            [hsx|
+                <li>
+                    <a href={pathTo ShowCliRunAction { cliRunId = cliRunId run }}>
+                        {cliRunCommand run}
+                    </a>
+                </li>
+            |]

--- a/gui/Application/View/CliRuns/Show.hs
+++ b/gui/Application/View/CliRuns/Show.hs
@@ -1,0 +1,19 @@
+module Application.View.CliRuns.Show where
+
+import Application.View.Prelude
+import Application.Controller.CliRunsController (CliRunsController (CliRunsAction, ShowCliRunAction))
+import qualified Data.Text as T
+
+data ShowView = ShowView { cliRun :: CliRun }
+
+instance View ShowView where
+    html ShowView { .. } =
+        layout
+            [hsx|
+                <h1>Cli Run Detail</h1>
+                <p><strong>Command:</strong> {cliRunCommand cliRun}</p>
+                <p><strong>Args:</strong> {T.intercalate " " (cliRunArgs cliRun)}</p>
+                <p><strong>Status:</strong> {cliRunStatus cliRun}</p>
+                <pre>{cliRunOutput cliRun}</pre>
+                <p><a href={pathTo CliRunsAction}>Back</a></p>
+            |]

--- a/gui/Test/CliRunServiceTest.hs
+++ b/gui/Test/CliRunServiceTest.hs
@@ -2,9 +2,14 @@ module CliRunServiceTest where
 
 import Test.Tasty.Hspec
 import Application.Service.CliRunService
+import Data.UUID (UUID)
 
 spec_cliRunService :: Spec
 spec_cliRunService = describe "CliRunService" $ do
     it "listCliRuns returns []" $ do
         runs <- listCliRuns
         runs `shouldBe` []
+    it "findCliRun returns Nothing for unknown id" $ do
+        let sampleId = read "00000000-0000-0000-0000-000000000000" :: UUID
+        result <- findCliRun sampleId
+        result `shouldBe` Nothing

--- a/gui/Test/CliRunsControllerTest.hs
+++ b/gui/Test/CliRunsControllerTest.hs
@@ -2,8 +2,13 @@ module CliRunsControllerTest where
 
 import Test.Tasty.Hspec
 import Application.Controller.CliRunsController
+import Data.UUID (UUID)
 
 spec_cliRunsController :: Spec
 spec_cliRunsController = describe "CliRunsController" $ do
     it "has CliRunsAction" $ do
         show CliRunsAction `shouldBe` "CliRunsAction"
+    it "has ShowCliRunAction" $ do
+        let sampleId = read "00000000-0000-0000-0000-000000000000" :: UUID
+        case ShowCliRunAction sampleId of
+            ShowCliRunAction{} -> True `shouldBe` True

--- a/gui/build/Generated/Types.hs
+++ b/gui/build/Generated/Types.hs
@@ -1,8 +1,10 @@
 module Generated.Types where
 
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Data.UUID (UUID)
+import GHC.Generics (Generic)
 
 data User = User
     { userId :: UUID
@@ -20,3 +22,13 @@ data Post = Post
     , postCreatedAt :: UTCTime
     }
     deriving (Eq, Show)
+
+data CliRun = CliRun
+    { cliRunId :: UUID
+    , cliRunCommand :: Text
+    , cliRunArgs :: [Text]
+    , cliRunStatus :: Text
+    , cliRunOutput :: Text
+    , cliRunCreatedAt :: UTCTime
+    }
+    deriving (Eq, Show, Generic, FromJSON, ToJSON)


### PR DESCRIPTION
## Summary
- Load CLI run data from JSON and expose lookup helpers
- Expand controller and views for CLI run index and detail pages
- Provide Next.js hooks, components and routes for run detail UI

## Testing
- `npm test`
- `cabal test` *(fails: unexpected 'R' in App.cabal)*

------
https://chatgpt.com/codex/tasks/task_e_688d6fa001bc8333b3a3ef694dd4d740