### PR TITLE
Add admin controller and admin navigation link

### DIFF
--- a/gui/Application/Controller/AdminController.hs
+++ b/gui/Application/Controller/AdminController.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Application.Controller.AdminController where
+
+import Application.Controller.Prelude
+import Application.View.Admin.Index
+
+instance Controller AdminController where
+    action AdminAction = render IndexView
+
+-- | Controller for admin dashboard.
+data AdminController = AdminAction deriving (Eq, Show)

--- a/gui/Application/View/Admin/Index.hs
+++ b/gui/Application/View/Admin/Index.hs
@@ -1,0 +1,15 @@
+module Application.View.Admin.Index where
+
+import Application.View.Prelude
+
+data IndexView = IndexView
+
+instance View IndexView where
+    html IndexView = layout [hsx|
+        <h1>Admin Dashboard</h1>
+        <ul>
+            <li><a href="/Cli">CLI</a></li>
+            <li><a href="/Users">Users</a></li>
+            <li><a href="/Posts">Posts</a></li>
+        </ul>
+    |]

--- a/gui/Application/View/Layout.hs
+++ b/gui/Application/View/Layout.hs
@@ -3,4 +3,11 @@ module Application.View.Layout where
 import IHP.ViewPrelude
 
 layout :: Html -> Html
-layout inner = [hsx|<html><body>{inner}</body></html>|]
+layout inner = [hsx|
+    <html>
+        <body>
+            <nav><a href="/Admin">Admin</a></nav>
+            {inner}
+        </body>
+    </html>
+|]

--- a/gui/Main.hs
+++ b/gui/Main.hs
@@ -11,6 +11,7 @@ import Application.Controller.UsersController
 import Application.Controller.PostsController
 import Application.Controller.CliRunsController
 import Application.Controller.CliController
+import Application.Controller.AdminController
 
 instance FrontController RootApplication where
     controllers =
@@ -19,6 +20,7 @@ instance FrontController RootApplication where
           , parseRoute @"/Users" UsersAction
           , parseRoute @"/CliRuns" CliRunsAction
           , parseRoute @"/Cli" CliAction
+          , parseRoute @"/Admin" AdminAction
           , parseRoute @"/Users.json" UsersJsonAction
           , parseRoute @"/Posts.json" PostsJsonAction
           , parseRoute @"/CliRuns.json" CliRunsJsonAction


### PR DESCRIPTION
## Summary
- Add AdminController with AdminAction route
- Create admin index view with links to CLI, users and posts
- Add navigation link to /Admin

## Testing
- `make build` *(fails: No rule to make target '/Makefile.dist')*
- `ghc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1842ab0a083338956019c6ae92736