### PR TITLE
Add admin CLI runner

### DIFF
--- a/gui/Application/Controller/AdminController.hs
+++ b/gui/Application/Controller/AdminController.hs
@@ -3,9 +3,22 @@ module Application.Controller.AdminController where
 
 import Application.Controller.Prelude
 import Application.View.Admin.Index
+import Application.View.Admin.RunCli
+import Application.Service.CliService (runCliCommand)
 
 instance Controller AdminController where
     action AdminAction = render IndexView
 
+    action RunCliAction = do
+        cmd <- paramOrNothing @Text "cmd"
+        case cmd of
+            Just command -> do
+                jobId <- liftIO $ runCliCommand command
+                render RunCliView { jobId = Just jobId }
+            Nothing -> render RunCliView { jobId = Nothing }
+
 -- | Controller for admin dashboard.
-data AdminController = AdminAction deriving (Eq, Show)
+data AdminController
+    = AdminAction
+    | RunCliAction
+    deriving (Eq, Show)

--- a/gui/Application/View/Admin/Index.hs
+++ b/gui/Application/View/Admin/Index.hs
@@ -8,7 +8,8 @@ instance View IndexView where
     html IndexView = layout [hsx|
         <h1>Admin Dashboard</h1>
         <ul>
-            <li><a href="/Cli">CLI</a></li>
+            <li><a href="/Admin/RunCli">Run CLI Command</a></li>
+            <li><a href="/CliRuns">CLI Runs</a></li>
             <li><a href="/Users">Users</a></li>
             <li><a href="/Posts">Posts</a></li>
         </ul>

--- a/gui/Application/View/Admin/RunCli.hs
+++ b/gui/Application/View/Admin/RunCli.hs
@@ -1,0 +1,23 @@
+module Application.View.Admin.RunCli where
+
+import Application.View.Prelude
+import Application.Controller.AdminController (AdminController(..))
+import Data.UUID (UUID)
+
+-- | View for running CLI commands from the admin interface.
+data RunCliView = RunCliView { jobId :: Maybe UUID }
+
+instance View RunCliView where
+    html RunCliView { .. } = layout [hsx|
+        <h1>Run CLI Command</h1>
+        {formFor RunCliAction [hsx|
+            <div class="form-group">
+                <input type="text" name="cmd" class="form-control" placeholder="Enter command" />
+            </div>
+            <button type="submit" class="btn btn-primary">Run</button>
+        |]}
+        {case jobId of
+            Just jid -> [hsx|<p>Command started with Job ID: {show jid}</p>|]
+            Nothing -> mempty
+        }
+    |]

--- a/gui/Main.hs
+++ b/gui/Main.hs
@@ -21,6 +21,7 @@ instance FrontController RootApplication where
           , parseRoute @"/CliRuns" CliRunsAction
           , parseRoute @"/Cli" CliAction
           , parseRoute @"/Admin" AdminAction
+          , parseRoute @"/Admin/RunCli" RunCliAction
           , parseRoute @"/Users.json" UsersJsonAction
           , parseRoute @"/Posts.json" PostsJsonAction
           , parseRoute @"/CliRuns.json" CliRunsJsonAction


### PR DESCRIPTION
## Summary
- Add RunCliAction to AdminController to execute CLI commands
- Add RunCli view with command form and job feedback
- Wire up routes and admin dashboard links for CLI runner

## Testing
- `cabal test` *(fails: App.cabal parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68a218d7b44483339044f7db3b17d3e4